### PR TITLE
update formatting of tutorial notebooks

### DIFF
--- a/examples/xspec/bayesian-workflow/tutorials/tutorial_usage_plotbxa.ipynb
+++ b/examples/xspec/bayesian-workflow/tutorials/tutorial_usage_plotbxa.ipynb
@@ -5,7 +5,9 @@
    "id": "5223fe0b",
    "metadata": {},
    "source": [
-    "# PlotBXA example -- basic BXA usage & additional plotting\n",
+    "# PlotBXA example \n",
+    "\n",
+    "## Basic BXA usage & additional plotting\n",
     "\n",
     "This notebook aims to illustrate additional plotting features for BXA fitting results, as implemented in the PlotBXA class. The methods of this class will be demonstrated in a basic example of BXA fitting. For details on BXA usage and the underlying fitting algorithm please see refer to Johannes Buchner's detailed [BXA documentation](https://johannesbuchner.github.io/BXA/index.html) and [UltraNest documentation](https://johannesbuchner.github.io/UltraNest/readme.html), which also contain several useful examples. \n",
     "\n",
@@ -23,7 +25,7 @@
     "\n",
     "---\n",
     "This notebook was tested with:\n",
-    "- HEASOFT 6.32.1\n",
+    "- HEASOFT 6.33.1\n",
     "- Python 3.11.4\n",
     "- BXA 4.1.1\n",
     "- UltraNest 3.6.1"
@@ -807,7 +809,7 @@
     "\n",
     "Similarly, for a type 2 test (```plot_false_negative_test()```) we generate fake spectra assuming that model B is the 'real' model. How likely is it that we find a better evidence for model A, despite the fact that model B is the right one? Using the distribution of Bayes factors from the simulated data, we can assign a significance to the relative strengths of our best-fit models.\n",
     "\n",
-    "**Please note**: running the two PlotBXA methods mentioned above involves repeated fitting with BXA of two models. The run time for such a task will almost certainly be beyond even several tea breaks. For this reason, it is advised to use the multi-processing example given below and/or to run such evaluations overnight or on a large, multicore system or cluster. For this reason the examples of running these methods in this notebook are included to illustrate how to call the methods, but commented out in the cells below. An example of the resulting plot has been included in the 'examples' directory.\n"
+    "**Please note**: running the two PlotBXA methods mentioned above involves repeated fitting with BXA of two models. The run time for such a task will almost certainly be beyond even several tea breaks. For this reason, it is advised to use the multi-processing example given below and/or to run such evaluations overnight or on a large, multicore system or cluster. For this reason the examples of running these methods in this notebook are included to illustrate how to call the methods, but commented out in the cells below. An example of the resulting plot has been included in the 'examples' directory of the BXA installation (type1_test_plot.png).\n"
    ]
   },
   {
@@ -826,7 +828,7 @@
     "                                          #   NOTE: the order is important here: the simulated spectra will now be \n",
     "                                          #         based on the model from solver1\n",
     "#models  = [activate_mod1,activate_mod3]  #<= matches the order of the solvers\n",
-    "#spec_prefix = 'tt1_wabs-pl-g'            #<= label for the simulated spectra (prefix of their file name)\n",
+    "#spec_prefix = 'tt1_wabs_pl_g'            #<= label for the simulated spectra (prefix of their file name)\n",
     "#bq = 0.9                                 #<= quantile for the distribution of the Bayes factor to show in the plot\n",
     "#with XSilence():\n",
     "#    bayes_quantile = pbx.plot_false_positive_test(existing_data=False,  #<= there are no fit-results in place\n",
@@ -853,7 +855,7 @@
     "                                          #   NOTE: the order is important here: the simulated spectra will now be \n",
     "                                          #         based on the model from solver3\n",
     "#models  = [activate_mod1,activate_mod3]  #<= matches the order of the solvers\n",
-    "#spec_prefix = 'tt2_wabs-pl-g'            #<= label for the simulated spectra (prefix of their file name)\n",
+    "#spec_prefix = 'tt2_wabs_pl_g'            #<= label for the simulated spectra (prefix of their file name)\n",
     "#bq = 0.9                                 #<= quantile for the distribution of the Bayes factor to show in the plot\n",
     "#with XSilence():\n",
     "#    bayes_quantile = pbx.plot_false_negative_test(existing_data=False,  #<= there are no fit-results in place\n",
@@ -882,7 +884,7 @@
     "##### The quicker option (example here for the type 1 test): \n",
     "- a) generate the fake spectra (this can be done inside the notebook)\n",
     "- b) create the necessary command; the command is then best run in the terminal directly, not in the notebook\n",
-    "    - The command will run an external script: parallel_bxa_tt1.py. Additional information on multiprocessing is provided in this script\n",
+    "    - The command will run an external script: parallel_bxa_tt1.py (this script can be found in the BXA installation directory -> examples/xspec/bayesian_workflow/mp_scripts). Additional information on multiprocessing is provided in this script\n",
     "- c) inspect the results by simply loading them in, _after_ all the BXA fitting is done. The left plot shows the probability density of the Bayes factor and the right one the cumulative distribution."
    ]
   },
@@ -901,7 +903,7 @@
     "# from the solver, and store them in the directory 'fakeit_spectra'. This is the required set-up.\n",
     "\n",
     "nsample = 24\n",
-    "spec_prefix = 'tt1_wabs-pl-g'\n",
+    "spec_prefix = 'tt1_wabs_pl_g'\n",
     "sim_dir = 'fakeit_spectra'\n",
     "with XSilence():\n",
     "    _,_ = pbx._create_fake_spectra(solver1,'mod1',\n",

--- a/examples/xspec/bayesian-workflow/tutorials/tutorial_usage_plotxspec.ipynb
+++ b/examples/xspec/bayesian-workflow/tutorials/tutorial_usage_plotxspec.ipynb
@@ -1,11 +1,21 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99a6b73c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "7a454ff3",
    "metadata": {},
    "source": [
-    "# PlotXspec Example -- basic PyXspec usage & additional plotting\n",
+    "# PlotXspec Example\n",
+    "\n",
+    "## Basic PyXspec usage & additional plotting\n",
     "\n",
     "This notebook is aimed at illustrating the _basic_ usage of PyXspec, as well as a few supporting methods related to plotting. The supporing methods are part of the PlotXspec class. The notebook will cover how to load spectra, define a define a model and fit it to the data, and how to plot the results. PyXspec makes all Xspec functionality accessible through Python, so covers a much broader range of options than covered here. For further details on PyXspec usage, please see the [documentation](https://heasarc.gsfc.nasa.gov/xanadu/xspec/python/html/index.html).\n",
     "\n",
@@ -20,7 +30,7 @@
     "\n",
     "---\n",
     "This notebook was tested with:\n",
-    "- HEASOFT 6.32.1\n",
+    "- HEASOFT 6.33.1\n",
     "- Python 3.11.4"
    ]
   },


### PR DESCRIPTION
The updates include the following changes to the notebooks (designed to improve the presentation on the documentation pages):

- changed the headers which should address the issue in the HTML on the documentation pages
- added a little information on the external scripts (specifically: where to find them, that will be less obvious to users that are viewing the notebooks from the doc pages rather than in the directory within the BXA install)
- modified the filenames which seem to be causing problems when running fakeit, removing dashes. I am not able to reproduce the error it throws (***XSPEC Error: Invalid chars in file name), so I am not sure this will solve it; however, I cannot see any other possible issue with the filenames (the path is created using os.path.join, so there should also be no issue switching between Windows and Linux notation)