### PR TITLE
Updating priors for xspec to use correct bounds (soft)

### DIFF
--- a/bxa/xspec/priors.py
+++ b/bxa/xspec/priors.py
@@ -19,11 +19,11 @@ def create_uniform_prior_for(model, par):
 	The uniform prior gives equal weight in non-logarithmic scale.
 	"""
 	pval, pdelta, pmin, pbottom, ptop, pmax = par.values
-	print('  uniform prior for %s between %f and %f ' % (par.name, pmin, pmax))
+	print('  uniform prior for %s between %f and %f ' % (par.name, pbottom, ptop))
 	# TODO: should we use min/max or bottom/top?
-	low = float(pmin)
-	spread = float(pmax - pmin)
-	if pmin > 0 and pmax / pmin > 100:
+	low = float(pbottom)
+	spread = float(ptop - pbottom)
+	if pbottom > 0 and ptop / pbottom > 100:
 		print('   note: this parameter spans several dex. Should it be log-uniform (create_jeffreys_prior_for)?')
 	def uniform_transform(x): return x * spread + low
 	return dict(model=model, index=par._Parameter__index, name=par.name, 
@@ -44,11 +44,11 @@ def create_loguniform_prior_for(model, par):
 	pval, pdelta, pmin, pbottom, ptop, pmax = par.values
 	# TODO: should we use min/max or bottom/top?
 	#print '  ', par.values
-	print('  jeffreys prior for %s between %e and %e ' % (par.name, pmin, pmax))
-	if pmin == 0:
+	print('  jeffreys prior for %s between %e and %e ' % (par.name, pbottom, ptop))
+	if pbottom == 0:
 		raise Exception('You forgot to set reasonable parameter limits on %s' % par.name)
-	low = log10(pmin)
-	spread = log10(pmax) - log10(pmin)
+	low = log10(pbottom)
+	spread = log10(ptop) - log10(pbottom)
 	if spread > 10:
 		print('   note: this parameter spans *many* dex. Double-check the limits are reasonable.')
 	def log_transform(x): return x * spread + low
@@ -66,7 +66,7 @@ def create_gaussian_prior_for(model, par, mean, std):
 	pval, pdelta, pmin, pbottom, ptop, pmax = par.values
 	rv = scipy.stats.norm(mean, std)
 	def gauss_transform(x): 
-		return max(pmin, min(pmax, rv.ppf(x)))
+		return max(pbottom, min(ptop, rv.ppf(x)))
 	print('  gaussian prior for %s of %f +- %f' % (par.name, mean, std))
 	return dict(model=model, index=par._Parameter__index, name=par.name, 
 		transform=gauss_transform, aftertransform=lambda x: x)


### PR DESCRIPTION
The hard bounds in xspec are supposed to be used for defining strictly forbidden regions (e.g. negative values for absorption). Soft bounds are meant for the region within which the model is fit. Using the example of absorption: If one wants to fit between 1e20 and 1e25 cm^-2 but wants to be able to get the unabsorbed luminosity/flux, the bounds need to be pmin=0, pbottom=1e-2, ptop=1e3, pmax=1e3 (pmax can also be higher but must not be lower; xspec multiplies absorption by 1e22).