### PR TITLE
Modified fluxchain

### DIFF
--- a/bxa/xspec/solver.py
+++ b/bxa/xspec/solver.py
@@ -298,7 +298,7 @@ class BXASolver(object):
 		:param spectrum: spectrum to use for spectrum.flux
 		:param erange: argument to AllModels.calcFlux, energy range
 		:param nsamples: number of samples to consider (the default, None, means all)
-		:param isource: index of source in case multiple sources are defined. Can be obtained with function bxa.solver.get_isource. 
+		:param i_src: index of source in case multiple sources are defined. Can be obtained with function bxa.solver.get_isource. 
 		"""
 		# prefix = analyzer.outputfiles_basename
 		# modelnames = set([t['model'].name for t in transformations])

--- a/bxa/xspec/solver.py
+++ b/bxa/xspec/solver.py
@@ -284,7 +284,7 @@ class BXASolver(object):
 
 		return self.results
 
-	def create_flux_chain(self, spectrum, erange="2.0 10.0", nsamples=None, isource=0):
+	def create_flux_chain(self, spectrum, erange="2.0 10.0", nsamples=None, i_src=0):
 		"""
 		For each posterior sample, computes the flux in the given energy range.
 
@@ -311,7 +311,7 @@ class BXASolver(object):
 				AllModels.calcFlux(erange)
 				f = spectrum.flux
 				# compute flux in current energies
-				flux.append([f[6*isource+0], f[6*isource+3]])
+				flux.append([f[6*i_src+0], f[6*i_src+3]])
 
 			return numpy.array(flux)
 


### PR DESCRIPTION
Added possibility to specify isrc in create_fluxchain for Xspec. Necessary in some cases when multiple sources are loaded, because Xspec does not sort sources by their number and if the responses overlap, the wrong one may be used for flux calculation. Additionally added a function to extract isrc to be used.
Behaviour for scripts not specifying i_src is the same as before.

Example usage:

i_src = bxa.xspec.solver.get_isrc(Erange=[0.2, 8.0], ispectrum=1, isource=1)
flux = BXASolver.create_flux_chain(spectrum, erange='0.2 8.0', isource=int(i_src))[:,0]

Note that isource starts with lowest index 1 (Xspec indexing), i_src has lowest possible index 0 (python indexing).
Also note that it is important that the Erange in get_isrc matches that in create_flux_chain.